### PR TITLE
Make it keyboard accessible

### DIFF
--- a/src/lightbox.css
+++ b/src/lightbox.css
@@ -10,7 +10,10 @@
     background-size: cover;
     border-top: solid 2px #fff;
     border-right: solid 2px #fff;
-    cursor: pointer;
+}
+
+.lb-item:hover, .lb-item:focus {
+    opacity: 0.6;
 }
 
 

--- a/src/lightbox.vue
+++ b/src/lightbox.vue
@@ -1,9 +1,9 @@
 <template>
     <div class="lb" v-if="items.length>0">
         <div class="lb-grid" :class="[css,items.length>cells?'lb-grid-' + cells: 'lb-grid-' + items.length]">
-            <div class="lb-item" v-for="(src, i) in items" @click="show(i)" v-if="i<cells" :style="bg(src)">
+            <a class="lb-item" v-for="(src, i) in items" :href="items[i]" role="link" @click.prevent="show(i)" v-if="i<cells" :style="bg(src)">
                 <span class="lb-more" v-if="i==cells-1 && items.length - cells>0">{{ items.length - cells}}+</span>
-            </div>
+            </a>
         </div>
 
         <transition enter-active-class="animated fadeIn" leave-active-class="animated fadeOut">


### PR DESCRIPTION
- Allows users to tab to each photo and press Enter to open the lightbox.  No more mouse only operation.
- Converted tiles from <div> to <a>
- Added `.prevent` modifier to `@click`
- Added focus/hover styles to the photos.